### PR TITLE
Adding the steps regarding passing custom_data while creating a webhook user

### DIFF
--- a/docs/webhooks/create-haptik-user.md
+++ b/docs/webhooks/create-haptik-user.md
@@ -1,4 +1,4 @@
----
+# New Document---
 title: How to create/update a Haptik User
 ---
 
@@ -45,7 +45,8 @@ Content-Type: application/json
   "mobile_no": "<MOBILE_NO>",
   "email": "<EMAIL>",
   "name": "<NAME>",
-  "language_code": "<LANGUAGE_CODE>"
+  "language_code": "<LANGUAGE_CODE>",
+  "custom_data": "<CUSTOM_DATA FLAT JSON OBJECT>"
 }
 ```
 
@@ -60,6 +61,38 @@ Content-Type: application/json
 - phone model (optional) - Phone model/type that the user is using
 - os version (optional) - OS version of where the user is coming from (Android, iOS, Windows etc.)
 - package name (optional)- An identifier to differentiate between different Apps on the device (WhatsApp or custom client app)
+- custom_data (optional) - Any additional information about the user _(which could not be captured by any of the above fields)_ should be added as a part of this _flat JSON structure_. <br/>
+Thus, additional information like _country_, _city_, _date of birth_, etc. which needs to be stored along with the user, should go here. As:
+	```json
+	{
+		"country": "India",
+    	"city": "Mumbai",
+    	"date_of_birth": "25-03-1985"
+	}
+	```
+
+	**Rules for valid `custom_data` value:**
+	- The value assigned to `custom_data` should always be a _valid JSON_.
+	- This value should always be a _flat JSON_. In other words, no property can have a JSON object assigned to it. <br/> For instance, the below JSON, though a valid JSON in itself, will still be considered as an _invalid_ `custom_data` value since the property, _address_, is assigned a JSON object:
+		```json
+        {
+	    	"date_of_birth": "12-8-1993",
+			"address": {
+				"country": "India",
+				"state": "Goa"
+			}
+		}
+        ```
+		The suggested way is to flatten the above JSON as:
+	    ```json
+        {
+			"date_of_birth": "12-8-1993",
+			"country": "India",
+			"state": "Goa"
+		}
+        ```
+
+
 
 ### Response
 

--- a/docs/webhooks/create-haptik-user.md
+++ b/docs/webhooks/create-haptik-user.md
@@ -128,7 +128,7 @@ curl -X POST \
   -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>",
 	"custom_data": {
 	    "<key_1>": "<value_1>",
-      "<key_2>": "<value_2>"
+        "<key_2>": "<value_2>"
 	}}'
 ```
 ### Update User
@@ -141,6 +141,6 @@ curl -X PUT \
   -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>",
 	"custom_data": {
 	    "<key_1>": "<value_1>",
-      "<key_2>": "<value_2>"
+        "<key_2>": "<value_2>"
 	}}'
 ```

--- a/docs/webhooks/create-haptik-user.md
+++ b/docs/webhooks/create-haptik-user.md
@@ -127,9 +127,8 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>",
 	"custom_data": {
-	"country": "India",
-  "city": "Mumbai",
-  "date_of_birth": "25-03-1985"
+	    "<key_1>": "<value_1>",
+        "<key_2>": "<value_2>"
 	}}'
 ```
 ### Update User
@@ -139,9 +138,9 @@ curl -X PUT \
   -H 'Authorization: Bearer <TOKEN>' \
   -H 'client-id: <CLIENT_ID>' \
   -H 'Content-Type: application/json' \
-  -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>""custom_data": {
-	"country": "India",
-  "city": "Mumbai",
-  "date_of_birth": "25-03-1985"
+  -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>",
+	"custom_data": {
+	    "<key_1>": "<value_1>",
+        "<key_2>": "<value_2>"
 	}}'
 ```

--- a/docs/webhooks/create-haptik-user.md
+++ b/docs/webhooks/create-haptik-user.md
@@ -46,7 +46,7 @@ Content-Type: application/json
   "email": "<EMAIL>",
   "name": "<NAME>",
   "language_code": "<LANGUAGE_CODE>",
-  "custom_data": "<CUSTOM_DATA FLAT JSON OBJECT>"
+  "custom_data": "<FLAT JSON OBJECT>"
 }
 ```
 
@@ -125,7 +125,12 @@ curl -X POST \
   -H 'Authorization: Bearer <TOKEN>' \
   -H 'client-id: <CLIENT_ID>' \
   -H 'Content-Type: application/json' \
-  -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>"}'
+  -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>",
+	"custom_data": {
+	"country": "India",
+  "city": "Mumbai",
+  "date_of_birth": "25-03-1985"
+	}}'
 ```
 ### Update User
 ```
@@ -134,5 +139,9 @@ curl -X PUT \
   -H 'Authorization: Bearer <TOKEN>' \
   -H 'client-id: <CLIENT_ID>' \
   -H 'Content-Type: application/json' \
-  -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>"}'
+  -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>""custom_data": {
+	"country": "India",
+  "city": "Mumbai",
+  "date_of_birth": "25-03-1985"
+	}}'
 ```

--- a/docs/webhooks/create-haptik-user.md
+++ b/docs/webhooks/create-haptik-user.md
@@ -62,7 +62,7 @@ Content-Type: application/json
 - os version (optional) - OS version of where the user is coming from (Android, iOS, Windows etc.)
 - package name (optional)- An identifier to differentiate between different Apps on the device (WhatsApp or custom client app)
 - custom_data (optional) - Any additional information about the user _(which could not be captured by any of the above fields)_ should be added as a part of this _flat JSON structure_. <br/>
-Thus, additional information like _country_, _city_, _date of birth_, etc. which needs to be stored along with the user, should go here. As:
+Thus, additional information like _country_, _city_, _date of birth_, etc. which needs to be stored along with the user, should go here as:
 	```json
 	{
 		"country": "India",

--- a/docs/webhooks/create-haptik-user.md
+++ b/docs/webhooks/create-haptik-user.md
@@ -128,7 +128,7 @@ curl -X POST \
   -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>",
 	"custom_data": {
 	    "<key_1>": "<value_1>",
-        "<key_2>": "<value_2>"
+      "<key_2>": "<value_2>"
 	}}'
 ```
 ### Update User
@@ -141,6 +141,6 @@ curl -X PUT \
   -d '{"auth_id": "<AUTH_ID>", "name": "guest user", "language_code":"<LANGUAGE_CODE>",
 	"custom_data": {
 	    "<key_1>": "<value_1>",
-        "<key_2>": "<value_2>"
+      "<key_2>": "<value_2>"
 	}}'
 ```


### PR DESCRIPTION
Now, `custom_data` can also be passed while creating a webhook user. 
Accordingly, the steps have been added to the document to help readers work with the same.