### PR TITLE
Update the WebSDK Doc Link

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -103,7 +103,7 @@ module.exports = () => (
           title: 'Web SDK',
           description: 'Supercharge your app with AI powered Chatbots enabled by our powerful Javascript SDK',
           ctaText: 'Get Started',
-          ctaLink: 'https://hellohaptik.github.io/javascript_sdk/'
+          ctaLink: 'https://hellohaptik.github.io/javascript-xdk/'
         },
         {
           title: 'Webhooks',


### PR DESCRIPTION
We have new WebSDK and the link on the home page will be redirected to the new SDK's docs.