### PR TITLE
Add custom_data reference in integrating-custom-code.md

### DIFF
--- a/docs/bot-builder/integrations/integrating-custom-code.md
+++ b/docs/bot-builder/integrations/integrating-custom-code.md
@@ -43,6 +43,7 @@ def main(event, context):
     body = json.loads(event['body'])
     entities = body['entities']
     user_data = body['user']
+    # "custom_data" that is passed through SDK's during sign up can be accessed from body['user_details'].
     user_details = body['user_details']
     conversation_details = body['conversation_details']
     final_response = {'status': True, 'response': write_here(), 'user_details':user_details, 'conversation_details':conversation_details}


### PR DESCRIPTION
Update the doc to specify how the `custom_data` passed during the sign up process in SDK's, can be accessed while implementing the code node.