### PR TITLE
Update the documentation for latest Android SDK release

### DIFF
--- a/docs/android-sdk/extension-module-integration.md
+++ b/docs/android-sdk/extension-module-integration.md
@@ -36,7 +36,7 @@ This module will enable the `Extensions` functionality in the Haptik SDK.
 Add the following in module `build.gradle` for eg: `build.gradle (Module: app)`
 
 ```java
-implementation 'ai.haptik.android.sdk:haptiklib-extensions:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-extensions:6.5.3-65483'
 ```
 
 ## Step 3: Configure Inbox Activity (Optional)

--- a/docs/android-sdk/image-loading-modules.md
+++ b/docs/android-sdk/image-loading-modules.md
@@ -26,7 +26,7 @@ Haptik SDK depends on these modules for image loading.
    - Add the following dependency to your module
    
 ```java
-implementation 'ai.haptik.android.sdk:haptiklib-picasso-helper:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-picasso-helper:6.5.3-65483'
 ```
 - Make the following changes to `InitData`
 
@@ -49,7 +49,7 @@ InitData initData = new InitData.Builder(application)
    - Add the following dependency to your module
    
 ```java
-implementation 'ai.haptik.android.sdk:haptiklib-glide-helper:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-glide-helper:6.5.3-65483'
 ```
 
 - Make the following changes to `InitData`

--- a/docs/android-sdk/index.md
+++ b/docs/android-sdk/index.md
@@ -71,13 +71,13 @@ Haptik will provide required username and password while providing access to the
 Once this is done you can move over to your app's `build.gradle` file and add the following lines of code:
 
 ```java
-implementation 'ai.haptik.android.sdk:haptiklib-core:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-core:6.5.3-65483'
 ```
 
 Add a dependency for image loading library
 
 ```java
-implementation 'ai.haptik.android.sdk:haptiklib-picasso-helper:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-picasso-helper:6.5.3-65483'
 ```
 
 For further details please refer to the "Image Loading Modules" section

--- a/docs/android-sdk/integrating-jio-communications-module.md
+++ b/docs/android-sdk/integrating-jio-communications-module.md
@@ -11,7 +11,7 @@ title: Integrating Jio Communications
 To enable the Jio Module you need to add the following dependency in the 
 
 ```java 
-implementation 'ai.haptik.android.sdk:haptiklib-jio-communications:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-jio-communications:6.5.3-65483'
 ```
 
 ## Step 2: Implementing JioCommunicationService

--- a/docs/android-sdk/migrating-from-earlier-versions.md
+++ b/docs/android-sdk/migrating-from-earlier-versions.md
@@ -1040,27 +1040,27 @@ implementation 'ai.haptik.android.sdk:haptiklib-xdk:6.5.1-65283'
 ```
 
 
-## Moving from 6.5.1 → 6.5.2
+## Moving from 6.5.2 → 6.5.3
 ```groovy
-implementation 'ai.haptik.android.sdk:haptiklib-core:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-core:6.5.3-65483'
 ```
 
 ```groovy
-implementation 'ai.haptik.android.sdk:haptiklib-extensions:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-extensions:6.5.3-65483'
 ```
 
 ```groovy
-implementation 'ai.haptik.android.sdk:haptiklib-picasso-helper:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-picasso-helper:6.5.3-65483'
 ```
 
 ```groovy
-implementation 'ai.haptik.android.sdk:haptiklib-glide-helper:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-glide-helper:6.5.3-65483'
 ```
 
 ```groovy
-implementation 'ai.haptik.android.sdk:haptiklib-jio-communications:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-jio-communications:6.5.3-65483'
 ```
 
 ```groovy
-implementation 'ai.haptik.android.sdk:haptiklib-xdk:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-xdk:6.5.3-65483'
 ```

--- a/docs/android-sdk/xdk-module-integration.md
+++ b/docs/android-sdk/xdk-module-integration.md
@@ -35,7 +35,7 @@ maven {
 Add the following in module `build.gradle` for eg: `build.gradle (Module: app)`
 
 ```groovy
-implementation 'ai.haptik.android.sdk:haptiklib-xdk:6.5.2-65383'
+implementation 'ai.haptik.android.sdk:haptiklib-xdk:6.5.3-65483'
 ```
 
 ## Target Android SDK 28


### PR DESCRIPTION
- Version numbers for the dependencies have now been changed to v6.5.3

CIA-6421