### PR TITLE
Update custom example code sample

### DIFF
--- a/docs/web-sdk/example-custom-button.md
+++ b/docs/web-sdk/example-custom-button.md
@@ -43,7 +43,7 @@ However, we would need to programmatically expand the XDK on click of our custom
           Steps: <br/>
           1) While defining haptikInitSettings simply add 'custom-button': true <br/>
           2) Add you icon, in this case we have directly used an img tag <br/>
-          3) On click of the icon and simply call 'HaptikSDK.expandWidget()' <br/>
+          3) On click of the icon, simply call 'HaptikSDK.expandWidget()' <br/>
           <img src="https://s3.ap-south-1.amazonaws.com/tools-cdn/js-sdk/images/custom-chat-icon.png" class="custom-icon">
       </div>
     </div>

--- a/docs/web-sdk/example-custom-button.md
+++ b/docs/web-sdk/example-custom-button.md
@@ -12,7 +12,7 @@ Within initSettings we need to add the following setting. This will initialise t
 
 However, we would need to programmatically expand the XDK on click of our custom button using the following HaptikSDK method.
 ```
-  HaptikSDK.expandWidget()
+  HaptikSDK.show()
 ```
 
 ## Full Example:
@@ -43,7 +43,7 @@ However, we would need to programmatically expand the XDK on click of our custom
           Steps: <br/>
           1) While defining haptikInitSettings simply add 'custom-button': true <br/>
           2) Add you icon, in this case we have directly used an img tag <br/>
-          3) On click of the icon, simply call 'HaptikSDK.expandWidget()' <br/>
+          3) On click of the icon, simply call 'HaptikSDK.show()' <br/>
           <img src="https://s3.ap-south-1.amazonaws.com/tools-cdn/js-sdk/images/custom-chat-icon.png" class="custom-icon">
       </div>
     </div>
@@ -61,7 +61,7 @@ However, we would need to programmatically expand the XDK on click of our custom
   <script>
     document.addEventListener('haptik_sdk', function () {
           document.getElementsByClassName("custom-icon")[0].addEventListener("click", function () {
-                  HaptikSDK.expandWidget();
+                  HaptikSDK.show();
           });
       });
   </script>

--- a/docs/web-sdk/example-custom-button.md
+++ b/docs/web-sdk/example-custom-button.md
@@ -12,7 +12,7 @@ Within initSettings we need to add the following setting. This will initialise t
 
 However, we would need to programmatically expand the XDK on click of our custom button using the following HaptikSDK method.
 ```
-  HaptikSDK.show()
+  HaptikSDK.expandWidget()
 ```
 
 ## Full Example:
@@ -43,8 +43,8 @@ However, we would need to programmatically expand the XDK on click of our custom
           Steps: <br/>
           1) While defining haptikInitSettings simply add 'custom-button': true <br/>
           2) Add you icon, in this case we have directly used an img tag <br/>
-          3) On click of the icon, create a function that simply calls 'HaptikSDK.expandWidget()' <br/>
-          <img onClick="HaptikSDK.show()" src="https://s3.ap-south-1.amazonaws.com/tools-cdn/js-sdk/images/custom-chat-icon.png" class="custom-icon">
+          3) On click of the icon and simply call 'HaptikSDK.expandWidget()' <br/>
+          <img src="https://s3.ap-south-1.amazonaws.com/tools-cdn/js-sdk/images/custom-chat-icon.png" class="custom-icon">
       </div>
     </div>
   </body>
@@ -59,9 +59,12 @@ However, we would need to programmatically expand the XDK on click of our custom
   </script>
   <script type="text/javascript" charset="UTF-8" src="https://toolassets.haptikapi.com/platform/javascript-xdk/production/loader.js"></script>
   <script>
-  function openChat() {
-    HaptikSDK.show()
-  }
+    document.addEventListener('haptik_sdk', function () {
+            document.getElementsByClassName("custom-icon")[0].addEventListener("click", function () {
+                    HaptikSDK.expandWidget();
+            });
+        });
+    }
   </script>
   </html>
 ```

--- a/docs/web-sdk/example-custom-button.md
+++ b/docs/web-sdk/example-custom-button.md
@@ -43,7 +43,7 @@ However, we would need to programmatically expand the XDK on click of our custom
           Steps: <br/>
           1) While defining haptikInitSettings simply add 'custom-button': true <br/>
           2) Add you icon, in this case we have directly used an img tag <br/>
-          3) On click of the icon, simply call 'HaptikSDK.show()' <br/>
+          3) After HaptikSDK is intialised, add a click listener on the icon and simply call 'HaptikSDK.show()' in it. Demonstrated in the script tag below. <br/>
           <img src="https://s3.ap-south-1.amazonaws.com/tools-cdn/js-sdk/images/custom-chat-icon.png" class="custom-icon">
       </div>
     </div>

--- a/docs/web-sdk/example-custom-button.md
+++ b/docs/web-sdk/example-custom-button.md
@@ -60,11 +60,10 @@ However, we would need to programmatically expand the XDK on click of our custom
   <script type="text/javascript" charset="UTF-8" src="https://toolassets.haptikapi.com/platform/javascript-xdk/production/loader.js"></script>
   <script>
     document.addEventListener('haptik_sdk', function () {
-            document.getElementsByClassName("custom-icon")[0].addEventListener("click", function () {
-                    HaptikSDK.expandWidget();
-            });
-        });
-    }
+          document.getElementsByClassName("custom-icon")[0].addEventListener("click", function () {
+                  HaptikSDK.expandWidget();
+          });
+      });
   </script>
   </html>
 ```

--- a/docs/web-sdk/feature-custom-button.md
+++ b/docs/web-sdk/feature-custom-button.md
@@ -51,7 +51,7 @@ The HaptikSDK provides us `HaptikSDK.show()` and `HaptikSDK.hide()` methods whic
           Steps: <br/>
           1) While defining haptikInitSettings simply add 'custom-button': true <br/>
           2) Add your icon, in this case we have directly used an img tag <br/>
-          3) On click of the icon, simply call 'HaptikSDK.show()' <br/>
+          3) After HaptikSDK is intialised, add a click listener on the icon and simply call 'HaptikSDK.show()' in it. Demonstrated in the script tag below. <br/>
           <img src="https://s3.ap-south-1.amazonaws.com/tools-cdn/js-sdk/images/custom-chat-icon.png" class="custom-icon">
       </div>
     </div>

--- a/docs/web-sdk/feature-custom-button.md
+++ b/docs/web-sdk/feature-custom-button.md
@@ -51,8 +51,8 @@ The HaptikSDK provides us `HaptikSDK.show()` and `HaptikSDK.hide()` methods whic
           Steps: <br/>
           1) While defining haptikInitSettings simply add 'custom-button': true <br/>
           2) Add your icon, in this case we have directly used an img tag <br/>
-          3) On click of the icon, create a function that simply calls 'HaptikSDK.show()' <br/>
-          <img onClick="openChat()" src="https://s3.ap-south-1.amazonaws.com/tools-cdn/js-sdk/images/custom-chat-icon.png" class="custom-icon">
+          3) On click of the icon, simply call 'HaptikSDK.show()' <br/>
+          <img src="https://s3.ap-south-1.amazonaws.com/tools-cdn/js-sdk/images/custom-chat-icon.png" class="custom-icon">
       </div>
     </div>
   </body>
@@ -67,9 +67,11 @@ The HaptikSDK provides us `HaptikSDK.show()` and `HaptikSDK.hide()` methods whic
   </script>
   <script type="text/javascript" charset="UTF-8" src="https://toolassets.haptikapi.com/platform/javascript-xdk/production/loader.js"></script>
   <script>
-  function openChat() {
-    HaptikSDK.show()
-  }
+      document.addEventListener('haptik_sdk', function () {
+          document.getElementsByClassName("custom-icon")[0].addEventListener("click", function () {
+                  HaptikSDK.show();
+          });
+      });
   </script>
   </html>
 ```


### PR DESCRIPTION
Currently the custom icon did not include to add the custom icon click handling only after HaptikSDK is initialised.

That is updated now.