### PR TITLE
Add documentation for new fields added to `webhook_conversation_complete` event

### DIFF
--- a/docs/webhooks/webhook-payload.md
+++ b/docs/webhooks/webhook-payload.md
@@ -280,7 +280,8 @@ Example:
         "chat_link":"<CHAT_LINK>", // deprecated. use `complete_chat_link` instead
         "complete_chat_link": "<CHAT_LINK>",
 		"completion_type": "agent", // possible values 'gogo', 'agent', 'autocomplete' depends who marked the chat complete
-    	"completion_by": "<AGENT_CLAIM_NAME>", //the state of a conversation before it was marked as completed. Possible values 'AGENT_CLAIM_NAME', 'Team Offline Flag', 'Waiting for User', 'Bot compeleted'
+    	"completion_by": "<AGENT_CLAIM_NAME>", // the state of a conversation before it was marked as completed.
+		                              //Possible values 'AGENT_CLAIM_NAME', 'Team Offline Flag', 'Waiting for User', 'Bot completed'
         "closing_categories": {
             "reason": "",
             "subReason": "",

--- a/docs/webhooks/webhook-payload.md
+++ b/docs/webhooks/webhook-payload.md
@@ -279,6 +279,8 @@ Example:
         "conversation_identifier": "<CONVERSATION_IDENTIFIER>",
         "chat_link":"<CHAT_LINK>", // deprecated. use `complete_chat_link` instead
         "complete_chat_link": "<CHAT_LINK>",
+		"completion_type": "agent", // possible values 'gogo', 'agent', 'autocomplete' depends who marked the chat complete
+    	"completion_by": "<AGENT_CLAIM_NAME>", //the state of a conversation before it was marked as completed. Possible values 'AGENT_CLAIM_NAME', 'Team Offline Flag', 'Waiting for User', 'Bot compeleted'
         "closing_categories": {
             "reason": "",
             "subReason": "",


### PR DESCRIPTION
- Add fields `completion_by` and `completion_type` to `data` object in the `webhook_conversation_complete` event
- `completion_type` indicates who completed the conversation
- `completion_by` indicates the state of the conversation before it was marked as complete.